### PR TITLE
Task config avoidance

### DIFF
--- a/src/main/groovy/com/github/eirnym/js2p/GenerateJsonSchemaJavaTask.groovy
+++ b/src/main/groovy/com/github/eirnym/js2p/GenerateJsonSchemaJavaTask.groovy
@@ -40,6 +40,9 @@ class GenerateJsonSchemaJavaTask extends DefaultTask {
         project.tasks.named('compileJava').configure {
             it.dependsOn(this)
         }
+        project.plugins.withId('java', {
+            project.sourceSets.main.java.srcDirs project.getExtensions().getByType(JsonSchemaExtension).targetDirectoryProperty
+        })
         project.afterEvaluate {
             configuration = project.jsonSchema2Pojo
 
@@ -55,8 +58,6 @@ class GenerateJsonSchemaJavaTask extends DefaultTask {
     }
 
     def configureJava() {
-        project.sourceSets.main.java.srcDirs += [configuration.targetDirectory]
-
         if (!configuration.source.hasNext()) {
             configuration.source = project.files("${project.sourceSets.main.output.resourcesDir}/json")
             configuration.sourceFiles.each { it.mkdir() }

--- a/src/main/groovy/com/github/eirnym/js2p/GenerateJsonSchemaJavaTask.groovy
+++ b/src/main/groovy/com/github/eirnym/js2p/GenerateJsonSchemaJavaTask.groovy
@@ -36,6 +36,10 @@ class GenerateJsonSchemaJavaTask extends DefaultTask {
         group = 'Build'
         outputs.dir project.getExtensions().getByType(JsonSchemaExtension).targetDirectoryProperty
 
+        dependsOn project.tasks.named('processResources')
+        project.tasks.named('compileJava').configure {
+            it.dependsOn(this)
+        }
         project.afterEvaluate {
             configuration = project.jsonSchema2Pojo
 
@@ -52,8 +56,6 @@ class GenerateJsonSchemaJavaTask extends DefaultTask {
 
     def configureJava() {
         project.sourceSets.main.java.srcDirs += [configuration.targetDirectory]
-        dependsOn(project.tasks.processResources)
-        project.tasks.compileJava.dependsOn(this)
 
         if (!configuration.source.hasNext()) {
             configuration.source = project.files("${project.sourceSets.main.output.resourcesDir}/json")

--- a/src/main/groovy/com/github/eirnym/js2p/GenerateJsonSchemaJavaTask.groovy
+++ b/src/main/groovy/com/github/eirnym/js2p/GenerateJsonSchemaJavaTask.groovy
@@ -34,18 +34,16 @@ class GenerateJsonSchemaJavaTask extends DefaultTask {
     GenerateJsonSchemaJavaTask() {
         description = 'Generates Java classes from a json schema.'
         group = 'Build'
+        outputs.dir project.getExtensions().getByType(JsonSchemaExtension).targetDirectoryProperty
 
         project.afterEvaluate {
             configuration = project.jsonSchema2Pojo
-            configuration.targetDirectory = configuration.targetDirectory ?:
-                    project.file("${project.buildDir}/generated-sources/js2p")
 
             if (project.plugins.hasPlugin('java')) {
                 configureJava()
             } else {
                 throw new GradleException('generateJsonSchema: Java plugin is required')
             }
-            outputs.dir configuration.targetDirectory
 
             inputs.property("configuration", configuration.toString())
             inputs.files project.files(configuration.sourceFiles)

--- a/src/main/groovy/com/github/eirnym/js2p/JsonSchemaExtension.groovy
+++ b/src/main/groovy/com/github/eirnym/js2p/JsonSchemaExtension.groovy
@@ -15,6 +15,9 @@
  */
 package com.github.eirnym.js2p
 
+import org.gradle.api.file.DirectoryProperty
+import org.gradle.api.file.ProjectLayout
+import org.gradle.api.model.ObjectFactory
 import org.jsonschema2pojo.AnnotationStyle
 import org.jsonschema2pojo.Annotator
 import org.jsonschema2pojo.AllFileFilter
@@ -26,6 +29,8 @@ import org.jsonschema2pojo.SourceSortOrder
 import org.jsonschema2pojo.SourceType
 import org.jsonschema2pojo.rules.RuleFactory
 
+import javax.inject.Inject
+
 /**
  * The configuration properties.
  *
@@ -34,7 +39,7 @@ import org.jsonschema2pojo.rules.RuleFactory
  */
 public class JsonSchemaExtension implements GenerationConfig {
   Iterable<File> sourceFiles
-  File targetDirectory
+  final DirectoryProperty targetDirectory
   String targetPackage
   AnnotationStyle annotationStyle
   boolean useTitleAsClassname
@@ -98,7 +103,8 @@ public class JsonSchemaExtension implements GenerationConfig {
   Language targetLanguage
   Map<String, String> formatTypeMapping
 
-  public JsonSchemaExtension() {
+  @Inject
+  public JsonSchemaExtension(ProjectLayout projectLayout, ObjectFactory objectFactory) {
     // See DefaultGenerationConfig
     generateBuilders = false
     includeJsonTypeInfoAnnotation = false
@@ -156,6 +162,7 @@ public class JsonSchemaExtension implements GenerationConfig {
     refFragmentPathDelimiters = "#/."
     sourceSortOrder = SourceSortOrder.OS
     formatTypeMapping = Collections.emptyMap()
+    targetDirectory = objectFactory.directoryProperty().convention(projectLayout.buildDirectory.dir("generated-sources/js2p"))
   }
 
   @Override
@@ -228,7 +235,7 @@ public class JsonSchemaExtension implements GenerationConfig {
        |includeJsonTypeInfoAnnotation = ${includeJsonTypeInfoAnnotation}
        |usePrimitives = ${usePrimitives}
        |source = ${sourceFiles}
-       |targetDirectory = ${targetDirectory}
+       |targetDirectory = ${getTargetDirectory()}
        |targetPackage = ${targetPackage}
        |propertyWordDelimiters = ${Arrays.toString(propertyWordDelimiters)}
        |useLongIntegers = ${useLongIntegers}
@@ -292,4 +299,11 @@ public class JsonSchemaExtension implements GenerationConfig {
     return formatDateTimes
   }
 
+  public File getTargetDirectory() {
+    return targetDirectory.get().asFile
+  }
+
+  DirectoryProperty getTargetDirectoryProperty() {
+    return targetDirectory
+  }
 }


### PR DESCRIPTION
To reduce `project.afterEvaluate` and apply [task config avoidance](https://docs.gradle.org/current/userguide/task_configuration_avoidance.html), this PR suggests `project.tasks.named('taskname')` and `project.plugins.withId('java', { ... })`.

In the next PR, I want to suggest changing `sourceFiles` in `JsonSchemaExtension` to [`ConfigurableFileCollection`](https://docs.gradle.org/current/userguide/lazy_configuration.html#property_files_api_reference). The change could be larger so I want to send this PR first separately.

update: I've prepared the [coming change](https://github.com/KengoTODA/js2p-gradle/compare/KengoTODA:04912c5...KengoTODA:daf12b9). I will create a new PR after we merge this one.