### PR TITLE
Remove the project.afterEvaluate for java project

### DIFF
--- a/src/main/groovy/com/github/eirnym/js2p/GenerateJsonSchemaJavaTask.groovy
+++ b/src/main/groovy/com/github/eirnym/js2p/GenerateJsonSchemaJavaTask.groovy
@@ -28,46 +28,26 @@ import org.jsonschema2pojo.Jsonschema2Pojo
  * @author Ben Manes (ben.manes@gmail.com)
  */
 class GenerateJsonSchemaJavaTask extends DefaultTask {
-    @Internal
-    GenerationConfig configuration
-
     GenerateJsonSchemaJavaTask() {
         description = 'Generates Java classes from a json schema.'
         group = 'Build'
-        def extension = project.getExtensions().getByType(JsonSchemaExtension)
-        outputs.dir extension.targetDirectoryProperty
-
         dependsOn project.tasks.named('processResources')
-        project.tasks.named('compileJava').configure {
-            it.dependsOn(this)
-        }
-        project.plugins.withId('java', {
-            project.sourceSets.main.java.srcDirs extension.targetDirectoryProperty
-        })
-        inputs.files({ extension.sourceFiles.filter({ it.exists() }) })
+
+        def configuration = project.getExtensions().getByType(JsonSchemaExtension)
+
+        project.sourceSets.main.java.srcDirs configuration.targetDirectoryProperty
+        configuration.sourceFiles.setFrom project.files("${project.sourceSets.main.output.resourcesDir}/json")
+        configuration.sourceFiles.each { it.mkdir() }
+
+        inputs.files({ configuration.sourceFiles.filter({ it.exists() }) })
                 .skipWhenEmpty()
-        project.afterEvaluate {
-            configuration = project.jsonSchema2Pojo
-
-            if (project.plugins.hasPlugin('java')) {
-                configureJava()
-            } else {
-                throw new GradleException('generateJsonSchema: Java plugin is required')
-            }
-
-            inputs.property("configuration", configuration.toString())
-        }
-    }
-
-    def configureJava() {
-        if (!configuration.source.hasNext()) {
-            configuration.sourceFiles.setFrom project.files("${project.sourceSets.main.output.resourcesDir}/json")
-            configuration.sourceFiles.each { it.mkdir() }
-        }
+        inputs.property('configuration', { configuration.toString() })
+        outputs.dir configuration.targetDirectoryProperty
     }
 
     @TaskAction
     def generate() {
+        def configuration = project.getExtensions().getByType(JsonSchemaExtension)
         if (Boolean.TRUE == configuration.properties.get("useCommonsLang3")) {
             logger.warn 'useCommonsLang3 is deprecated. Please remove it from your config.'
         }

--- a/src/main/groovy/com/github/eirnym/js2p/JsonSchemaExtension.groovy
+++ b/src/main/groovy/com/github/eirnym/js2p/JsonSchemaExtension.groovy
@@ -15,7 +15,9 @@
  */
 package com.github.eirnym.js2p
 
+import org.gradle.api.file.ConfigurableFileCollection
 import org.gradle.api.file.DirectoryProperty
+import org.gradle.api.file.FileCollection
 import org.gradle.api.file.ProjectLayout
 import org.gradle.api.model.ObjectFactory
 import org.jsonschema2pojo.AnnotationStyle
@@ -38,7 +40,7 @@ import javax.inject.Inject
  * @see https://github.com/joelittlejohn/jsonschema2pojo
  */
 public class JsonSchemaExtension implements GenerationConfig {
-  Iterable<File> sourceFiles
+  final ConfigurableFileCollection sourceFiles
   final DirectoryProperty targetDirectory
   String targetPackage
   AnnotationStyle annotationStyle
@@ -110,7 +112,7 @@ public class JsonSchemaExtension implements GenerationConfig {
     includeJsonTypeInfoAnnotation = false
     useInnerClassBuilders = false
     usePrimitives = false
-    sourceFiles = []
+    sourceFiles = objectFactory.fileCollection()
     targetPackage = ''
     propertyWordDelimiters = ['-', ' ', '_'] as char[]
     useLongIntegers = false
@@ -177,17 +179,11 @@ public class JsonSchemaExtension implements GenerationConfig {
 
   @Override
   public Iterator<URL> getSource() {
-    def urlList = []
-    for (source in sourceFiles) {
-      urlList.add(source.toURI().toURL())
-    }
-    urlList.iterator()
+    sourceFiles.asList().stream().map({ it.toURI().toURL() }).iterator()
   }
 
   public void setSource(Iterable<File> files) {
-    def copy = [] as List
-    files.each { copy.add(it) }
-    sourceFiles = copy
+    sourceFiles.setFrom files
   }
 
   public void setAnnotationStyle(String style) {
@@ -234,7 +230,7 @@ public class JsonSchemaExtension implements GenerationConfig {
     """|generateBuilders = ${generateBuilders}
        |includeJsonTypeInfoAnnotation = ${includeJsonTypeInfoAnnotation}
        |usePrimitives = ${usePrimitives}
-       |source = ${sourceFiles}
+       |source = ${sourceFiles.asList()}
        |targetDirectory = ${getTargetDirectory()}
        |targetPackage = ${targetPackage}
        |propertyWordDelimiters = ${Arrays.toString(propertyWordDelimiters)}

--- a/src/main/groovy/com/github/eirnym/js2p/JsonSchemaPlugin.groovy
+++ b/src/main/groovy/com/github/eirnym/js2p/JsonSchemaPlugin.groovy
@@ -30,9 +30,15 @@ class JsonSchemaPlugin implements Plugin<Project> {
     @Override
     public void apply(Project project) {
         project.extensions.create('jsonSchema2Pojo', JsonSchemaExtension)
+        project.plugins.withId('java') {
+            def js2pTask = project.tasks.register('generateJsonSchema2Pojo', GenerateJsonSchemaJavaTask)
+            project.tasks.named('compileJava').configure {
+                it.dependsOn(js2pTask)
+            }
+        }
         project.afterEvaluate {
             if (project.plugins.hasPlugin('java')) {
-                project.tasks.create('generateJsonSchema2Pojo', GenerateJsonSchemaJavaTask)
+                // do nothing
             } else if (project.plugins.hasPlugin('com.android.application') || project.plugins.hasPlugin('com.android.library')) {
                 def config = project.jsonSchema2Pojo
                 def variants = null

--- a/src/test/groovy/com/github/eirnym/js2p/JavaTaskFunctionalTest.groovy
+++ b/src/test/groovy/com/github/eirnym/js2p/JavaTaskFunctionalTest.groovy
@@ -81,7 +81,6 @@ class JavaTaskFunctionalTest {
     }
 
     @Test
-    @Disabled("this test fails with the version 1.0")
     @DisplayName('generateJsonSchema2Pojo task skips if no json file exists')
     void noJsonFiles() {
         createBuildFiles()


### PR DESCRIPTION
If we apply changes to the project in `project.afterEvaluate`, it makes other plugins confused.
It is also not good for performance, so I'll suggest replacing it with [lazy configuration](https://docs.gradle.org/current/userguide/lazy_configuration.html) that configures tasks/projects on demand.

This change also introduces a fix around task optimization: Now task will be marked as `NO_SOURCE` and skipped if there is no JSON file to handle.